### PR TITLE
Fix detection of running salt-master, when setproctitle extension has been installed

### DIFF
--- a/pepperboard/core/__init__.py
+++ b/pepperboard/core/__init__.py
@@ -29,6 +29,8 @@ def getmasterstatus():
     for proc in psutil.process_iter():
         if proc.name() == 'salt-master':
             return 0
+        if len(proc.cmdline()) > 0 and 'salt-master' in proc.cmdline()[0]:
+            return 0
     return 1
 
 


### PR DESCRIPTION
setproctitle is a python extension which changes visible cmdline of running python scripts
as to better describe what each process/thread is intended for, helping when diganosing or
tracing issues.
However, pepperboard tries to find a process named 'salt-master' which does not conform to
how cmdline of a salt-master running with setproctitle appears on psutils.